### PR TITLE
Fix GitHub Packaging Error for Untriggered Workflows

### DIFF
--- a/checks/raw/github/packaging.go
+++ b/checks/raw/github/packaging.go
@@ -16,6 +16,7 @@ package github
 
 import (
 	"fmt"
+	"github.com/ossf/scorecard/v4/clients"
 	"path/filepath"
 
 	"github.com/rhysd/actionlint"
@@ -32,6 +33,7 @@ func Packaging(c *checker.CheckRequest) (checker.PackagingData, error) {
 	if err != nil {
 		return data, fmt.Errorf("%w", err)
 	}
+
 	if err != nil {
 		return data, fmt.Errorf("RepoClient.ListFiles: %w", err)
 	}
@@ -65,9 +67,18 @@ func Packaging(c *checker.CheckRequest) (checker.PackagingData, error) {
 			continue
 		}
 
-		runs, err := c.RepoClient.ListSuccessfulWorkflowRuns(filepath.Base(fp))
+		workflowFilename := filepath.Base(fp)
+		hasWorkflow, err := c.RepoClient.HasWorkflowHistory(workflowFilename)
 		if err != nil {
-			return data, fmt.Errorf("Client.Actions.ListWorkflowRunsByFileName: %w", err)
+			return data, fmt.Errorf("Client.Actions.HasWorkflowHistory: %w", err)
+		}
+
+		var runs []clients.WorkflowRun
+		if hasWorkflow {
+			runs, err = c.RepoClient.ListSuccessfulWorkflowRuns(workflowFilename)
+			if err != nil {
+				return data, fmt.Errorf("Client.Actions.ListWorkflowRunsByFileName: %w", err)
+			}
 		}
 
 		if len(runs) > 0 {

--- a/clients/githubrepo/client.go
+++ b/clients/githubrepo/client.go
@@ -247,6 +247,11 @@ func (client *Client) ListLicenses() ([]clients.License, error) {
 	return client.licenses.listLicenses()
 }
 
+// HasWorkflowHistory implements RepoClient.HasWorkflowHistory.
+func (client *Client) HasWorkflowHistory(filename string) (bool, error) {
+	return client.workflows.hasWorkflowHistory(filename)
+}
+
 // Search implements RepoClient.Search.
 func (client *Client) Search(request clients.SearchRequest) (clients.SearchResponse, error) {
 	return client.search.search(request)

--- a/clients/gitlabrepo/client.go
+++ b/clients/gitlabrepo/client.go
@@ -272,6 +272,11 @@ func (client *Client) SearchCommits(request clients.SearchCommitsOptions) ([]cli
 	return client.searchCommits.search(request)
 }
 
+// HasWorkflowHistory implements RepoClient.HasWorkflowHistory.
+func (client *Client) HasWorkflowHistory(filename string) (bool, error) {
+	return false, fmt.Errorf("HasWorkflowHistory: %w", clients.ErrUnsupportedFeature)
+}
+
 func (client *Client) Close() error {
 	return nil
 }

--- a/clients/localdir/client.go
+++ b/clients/localdir/client.go
@@ -229,8 +229,6 @@ func (client *localDirClient) ListWebhooks() ([]clients.Webhook, error) {
 	return nil, fmt.Errorf("ListWebhooks: %w", clients.ErrUnsupportedFeature)
 }
 
-// HasWorkflowHistory implements RepoClient.HasWorkflowHistory.
-
 // Search implements RepoClient.Search.
 func (client *localDirClient) Search(request clients.SearchRequest) (clients.SearchResponse, error) {
 	return clients.SearchResponse{}, fmt.Errorf("Search: %w", clients.ErrUnsupportedFeature)

--- a/clients/localdir/client.go
+++ b/clients/localdir/client.go
@@ -229,6 +229,8 @@ func (client *localDirClient) ListWebhooks() ([]clients.Webhook, error) {
 	return nil, fmt.Errorf("ListWebhooks: %w", clients.ErrUnsupportedFeature)
 }
 
+// HasWorkflowHistory implements RepoClient.HasWorkflowHistory.
+
 // Search implements RepoClient.Search.
 func (client *localDirClient) Search(request clients.SearchRequest) (clients.SearchResponse, error) {
 	return clients.SearchResponse{}, fmt.Errorf("Search: %w", clients.ErrUnsupportedFeature)
@@ -261,6 +263,11 @@ func (client *localDirClient) GetCreatedAt() (time.Time, error) {
 
 func (client *localDirClient) GetOrgRepoClient(ctx context.Context) (clients.RepoClient, error) {
 	return nil, fmt.Errorf("GetOrgRepoClient: %w", clients.ErrUnsupportedFeature)
+}
+
+// HasWorkflowHistory implements RepoClient.HasWorkflowHistory.
+func (client *localDirClient) HasWorkflowHistory(filename string) (bool, error) {
+	return false, fmt.Errorf("HasWorkflowHistory: %w", clients.ErrUnsupportedFeature)
 }
 
 // CreateLocalDirClient returns a client which implements RepoClient interface.

--- a/clients/mockclients/repo_client.go
+++ b/clients/mockclients/repo_client.go
@@ -346,7 +346,7 @@ func (m *MockRepoClient) HasWorkflowHistory(filename string) (bool, error) {
 // HasWorkflowHistory indicates an expected call of HasWorkflowHistory.
 func (mr *MockRepoClientMockRecorder) HasWorkflowHistory(filename interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasWorkflowHistory", reflect.TypeOf((*MockRepoClient)(nil).ListSuccessfulWorkflowRuns), filename)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasWorkflowHistory", reflect.TypeOf((*MockRepoClient)(nil).HasWorkflowHistory), filename)
 }
 
 // ListWebhooks mocks base method.

--- a/clients/mockclients/repo_client.go
+++ b/clients/mockclients/repo_client.go
@@ -334,6 +334,21 @@ func (mr *MockRepoClientMockRecorder) ListSuccessfulWorkflowRuns(filename interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSuccessfulWorkflowRuns", reflect.TypeOf((*MockRepoClient)(nil).ListSuccessfulWorkflowRuns), filename)
 }
 
+// HasWorkflowHistory mocks base method.
+func (m *MockRepoClient) HasWorkflowHistory(filename string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasWorkflowHistory", filename)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasWorkflowHistory indicates an expected call of HasWorkflowHistory.
+func (mr *MockRepoClientMockRecorder) HasWorkflowHistory(filename interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasWorkflowHistory", reflect.TypeOf((*MockRepoClient)(nil).ListSuccessfulWorkflowRuns), filename)
+}
+
 // ListWebhooks mocks base method.
 func (m *MockRepoClient) ListWebhooks() ([]clients.Webhook, error) {
 	m.ctrl.T.Helper()

--- a/clients/ossfuzz/client.go
+++ b/clients/ossfuzz/client.go
@@ -271,3 +271,8 @@ func (c *client) ListLicenses() ([]clients.License, error) {
 func (c *client) GetCreatedAt() (time.Time, error) {
 	return time.Time{}, fmt.Errorf("GetCreatedAt: %w", clients.ErrUnsupportedFeature)
 }
+
+// HasWorkflowHistory implements RepoClient.HasWorkflowHistory.
+func (c *client) HasWorkflowHistory(filename string) (bool, error) {
+	return false, fmt.Errorf("HasWorkflowHistory: %w", clients.ErrUnsupportedFeature)
+}

--- a/clients/repo_client.go
+++ b/clients/repo_client.go
@@ -52,6 +52,7 @@ type RepoClient interface {
 	ListStatuses(ref string) ([]Status, error)
 	ListWebhooks() ([]Webhook, error)
 	ListProgrammingLanguages() ([]Language, error)
+	HasWorkflowHistory(filename string) (bool, error)
 	Search(request SearchRequest) (SearchResponse, error)
 	SearchCommits(request SearchCommitsOptions) ([]Commit, error)
 	Close() error


### PR DESCRIPTION
Fixed an issue where the GitHub packaging check would return an error for workflow files that exist but have no workflow history (because the workflow hasn't been triggered yet). 
