### PR TITLE
Update Scorecard to give an error when the GitHub rate limit is exceeded

### DIFF
--- a/clients/githubrepo/roundtripper/rate_limit.go
+++ b/clients/githubrepo/roundtripper/rate_limit.go
@@ -79,8 +79,7 @@ func (gh *rateLimitTransport) RoundTrip(r *http.Request) (*http.Response, error)
 		}
 
 		duration := time.Until(time.Unix(int64(reset), 0))
-		rateLimitExceeded := fmt.Sprintf("Github rate limit exceeded. Wait %s to retry...", duration)
-		return nil, fmt.Errorf(rateLimitExceeded)
+		return nil, fmt.Errorf("github rate limit exceeded. wait %s to retry", duration)
 	}
 
 	return resp, nil

--- a/clients/githubrepo/roundtripper/rate_limit.go
+++ b/clients/githubrepo/roundtripper/rate_limit.go
@@ -15,6 +15,7 @@
 package roundtripper
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -27,6 +28,8 @@ import (
 	sce "github.com/ossf/scorecard/v4/errors"
 	"github.com/ossf/scorecard/v4/log"
 )
+
+var errGitHubRateLimitExceeded = errors.New("github rate limit exceeded")
 
 // MakeRateLimitedTransport returns a RoundTripper which rate limits GitHub requests.
 func MakeRateLimitedTransport(innerTransport http.RoundTripper, logger *log.Logger) http.RoundTripper {
@@ -79,7 +82,7 @@ func (gh *rateLimitTransport) RoundTrip(r *http.Request) (*http.Response, error)
 		}
 
 		duration := time.Until(time.Unix(int64(reset), 0))
-		return nil, fmt.Errorf("github rate limit exceeded. wait %s to retry", duration)
+		return nil, fmt.Errorf("%w: wait %s to retry", errGitHubRateLimitExceeded, duration)
 	}
 
 	return resp, nil

--- a/clients/githubrepo/roundtripper/rate_limit.go
+++ b/clients/githubrepo/roundtripper/rate_limit.go
@@ -79,14 +79,8 @@ func (gh *rateLimitTransport) RoundTrip(r *http.Request) (*http.Response, error)
 		}
 
 		duration := time.Until(time.Unix(int64(reset), 0))
-		// TODO(log): Previously Warn. Consider logging an error here.
-		gh.logger.Info(fmt.Sprintf("Rate limit exceeded. Waiting %s to retry...", duration))
-
-		// Retry
-		time.Sleep(duration)
-		// TODO(log): Previously Warn. Consider logging an error here.
-		gh.logger.Info("Rate limit exceeded. Retrying...")
-		return gh.RoundTrip(r)
+		rateLimitExceeded := fmt.Sprintf("Github rate limit exceeded. Wait %s to retry...", duration)
+		return nil, fmt.Errorf(rateLimitExceeded)
 	}
 
 	return resp, nil


### PR DESCRIPTION
The previous behavior caused scans to become 'stuck' by waiting for the rate limit to reset. With this update, the scan will now fail immediately if the rate limit is exceeded